### PR TITLE
gadget: cloud-conf: set network configuration

### DIFF
--- a/gadget/cloud-conf/cloud.conf
+++ b/gadget/cloud-conf/cloud.conf
@@ -9,5 +9,12 @@
       ubuntu:ubuntu
     expire: True
   network:
-    config: disabled
+    version: 2
+    ethernets:
+      all-eth:
+        match:
+          name: "eth*"
+        optional: true
+        dhcp4: true
+        dhcp6: true
   datasource_list: [ NoCloud ]


### PR DESCRIPTION
Set the network configuration for the onboard Ethernet ports to use DHCP.

Additionally, set the network interfaces to "optional". This prevents the board from hanging during boot waiting for the network configuration.